### PR TITLE
for-direction rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tree-sitter-lint = { path = "../tree-sitter-lint" }
+
+[patch.crates-io]
+tree-sitter = { git = "https://github.com/helixbass/tree-sitter", rev = "57e98fb0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,12 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+use tree_sitter_lint::Plugin;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+mod rules;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+use rules::for_direction_rule;
+
+pub fn instantiate() -> Plugin {
+    Plugin {
+        name: "eslint-builtin".to_owned(),
+        rules: vec![for_direction_rule()],
     }
 }

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -81,7 +81,7 @@ pub fn for_direction_rule() -> Arc<dyn Rule> {
                     _ => unreachable!(),
                 } == wrong_direction {
                     context.report(violation! {
-                        node => node,
+                        node => captures["for_statement"],
                         message => "The update clause in this loop moves the variable in the wrong direction."
                     });
                 }

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+
+use tree_sitter_lint::{rule, violation, Rule};
+
+pub fn for_direction_rule() -> Arc<dyn Rule> {
+    rule! {
+        name => "for-direction",
+        languages => [Javascript],
+        listeners => [
+            r#"(
+              (for_statement
+                condition: (expression_statement
+                  (binary_expression
+                    left: (identifier) @counter
+                    operator: [
+                      "<"
+                      "<="
+                      ">"
+                      ">="
+                    ] @operator
+                  )
+                )
+                increment: [
+                  (update_expression
+                    argument: (identifier) @update_name (#eq? @counter @update_name)
+                    operator: [
+                      "++"
+                      "--"
+                    ] @update_operator
+                  )
+                  (augmented_assignment_expression
+                    left: (identifier) @update_name (#eq? @counter @update_name)
+                    operator: [
+                      "+="
+                      "-="
+                    ] @update_operator
+                    right: [
+                      (number)
+                      (unary_expression
+                        argument: (number)
+                        operator: "-"
+                      ) @update_right_reversed
+                    ]
+                  )
+                ]
+              ) @for_statement
+            )"# => |captures, context| {
+                #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+                enum Direction {
+                    Decreasing,
+                    Increasing
+                }
+
+                impl Direction {
+                    pub fn reversed(self) -> Self {
+                        match self {
+                            Self::Decreasing => Self::Increasing,
+                            Self::Increasing => Self::Decreasing,
+                        }
+                    }
+                }
+
+                let wrong_direction = match context.get_node_text(captures["operator"]) {
+                    "<" | "<=" => Direction::Decreasing,
+                    _ => Direction::Increasing,
+                };
+
+                let reverse_if_negated = |direction: Direction| {
+                    if captures.get("update_right_reversed").is_some() {
+                        direction
+                    } else {
+                        direction.reversed()
+                    }
+                };
+
+                if match context.get_node_text(captures["update_operator"]) {
+                    "++" => Direction::Increasing,
+                    "--" => Direction::Decreasing,
+                    "+=" => reverse_if_negated(Direction::Increasing),
+                    "-=" => reverse_if_negated(Direction::Decreasing),
+                    _ => unreachable!(),
+                } == wrong_direction {
+                    context.report(violation! {
+                        node => node,
+                        message => "The update clause in this loop moves the variable in the wrong direction."
+                    });
+                }
+            },
+        ]
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,0 +1,3 @@
+mod for_direction;
+
+pub use for_direction::for_direction_rule;


### PR DESCRIPTION
In this PR:
- Set up tree-sitter-lint plugin repo and add equivalent of ESLint `for-direction` rule

To test:
If you wanted to you should be able to add this as a local-path-dependency plugin to a local `.tree-sitter-lint.yml` and test it against `.js` project files