### PR TITLE
Node parent caching

### DIFF
--- a/.tree-sitter-lint.yml
+++ b/.tree-sitter-lint.yml
@@ -474,6 +474,12 @@ rules:
         FromFileRunContext:
           module: tree_sitter_lint
           kind: type
+        NodeParentCache:
+          module: tree_sitter_lint
+          kind: type
+        NodeParentProvider:
+          module: tree_sitter_lint
+          kind: type
         QueryMatchContext:
           module: tree_sitter_lint
           kind: type
@@ -484,6 +490,9 @@ rules:
           module: tree_sitter_lint
           kind: type
         RuleTestExpectedErrorBuilder:
+          module: tree_sitter_lint
+          kind: type
+        StandaloneNodeParentProvider:
           module: tree_sitter_lint
           kind: type
         SkipOptionsBuilder:
@@ -498,6 +507,10 @@ rules:
         violation:
           module: tree_sitter_lint
           kind: macro
+        field:
+          module: tree_sitter_lint
+          kind: trait_method
+          trait: NodeExt
         first_non_comment_named_child:
           module: tree_sitter_lint
           kind: trait_method
@@ -510,6 +523,10 @@ rules:
           module: tree_sitter_lint
           kind: trait_method
           trait: NodeExt
+        maybe_parent:
+          module: tree_sitter_lint
+          kind: trait_method
+          trait: NodeExt
         non_comment_named_children:
           module: tree_sitter_lint
           kind: trait_method
@@ -518,15 +535,15 @@ rules:
           module: tree_sitter_lint
           kind: trait_method
           trait: NodeExt
+        parent_:
+          module: tree_sitter_lint
+          kind: trait_method
+          trait: NodeExt
         text:
           module: tree_sitter_lint
           kind: trait_method
           trait: NodeExt
         tokens:
-          module: tree_sitter_lint
-          kind: trait_method
-          trait: NodeExt
-        field:
           module: tree_sitter_lint
           kind: trait_method
           trait: NodeExt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-# tree-sitter-lint = { git = "https://github.com/helixbass/tree-sitter-lint", rev = "aa43a1c" }
-tree-sitter-lint = { path = "../tree-sitter-lint" }
+tree-sitter-lint = { git = "https://github.com/helixbass/tree-sitter-lint", rev = "554d3bc" }
 
 [patch.crates-io]
 tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "660481d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-tree-sitter-lint = { git = "https://github.com/helixbass/tree-sitter-lint", rev = "aa43a1c" }
+# tree-sitter-lint = { git = "https://github.com/helixbass/tree-sitter-lint", rev = "aa43a1c" }
+tree-sitter-lint = { path = "../tree-sitter-lint" }
 
 [patch.crates-io]
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "c16b90d" }
+tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter", rev = "660481d" }

--- a/plugin/src/ast_helpers.rs
+++ b/plugin/src/ast_helpers.rs
@@ -46,11 +46,11 @@ use crate::kind::{
 macro_rules! assert_kind {
     ($node:expr, $kind:pat) => {
         assert!(
-                                                                    matches!($node.kind(), $kind),
-                                                                    "Expected kind {:?}, got: {:?}",
-                                                                    stringify!($kind),
-                                                                    $node.kind()
-                                                                );
+            matches!($node.kind(), $kind),
+            "Expected kind {:?}, got: {:?}",
+            stringify!($kind),
+            $node.kind()
+        );
     };
 }
 
@@ -58,8 +58,8 @@ macro_rules! assert_kind {
 macro_rules! return_default_if_false {
     ($expr:expr) => {
         if !$expr {
-                                                                    return Default::default();
-                                                                }
+            return Default::default();
+        }
     };
 }
 

--- a/plugin/src/ast_helpers.rs
+++ b/plugin/src/ast_helpers.rs
@@ -31,7 +31,10 @@ pub use number::{
     get_number_literal_string_value, get_number_literal_value, Number, NumberOrBigInt,
 };
 use squalid::EverythingExt;
-use tree_sitter_lint::tree_sitter::{Tree, TreeCursor};
+use tree_sitter_lint::{
+    tree_sitter::{Tree, TreeCursor},
+    NodeParentProvider,
+};
 
 use crate::kind::{
     ExportStatement, Function, FunctionDeclaration, GeneratorFunction,
@@ -43,11 +46,11 @@ use crate::kind::{
 macro_rules! assert_kind {
     ($node:expr, $kind:pat) => {
         assert!(
-            matches!($node.kind(), $kind),
-            "Expected kind {:?}, got: {:?}",
-            stringify!($kind),
-            $node.kind()
-        );
+                                                                    matches!($node.kind(), $kind),
+                                                                    "Expected kind {:?}, got: {:?}",
+                                                                    stringify!($kind),
+                                                                    $node.kind()
+                                                                );
     };
 }
 
@@ -55,8 +58,8 @@ macro_rules! assert_kind {
 macro_rules! return_default_if_false {
     ($expr:expr) => {
         if !$expr {
-            return Default::default();
-        }
+                                                                    return Default::default();
+                                                                }
     };
 }
 
@@ -135,10 +138,13 @@ pub enum MethodDefinitionKind {
     Set,
 }
 
-pub fn get_method_definition_kind(node: Node, context: &QueryMatchContext) -> MethodDefinitionKind {
+pub fn get_method_definition_kind<'a>(
+    node: Node<'a>,
+    context: &QueryMatchContext<'a, '_>,
+) -> MethodDefinitionKind {
     assert_kind!(node, MethodDefinition);
     let name = node.child_by_field_name("name").unwrap();
-    let is_object_method = node.parent().unwrap().kind() == Object;
+    let is_object_method = node.parent_(context).kind() == Object;
     if name.kind() == PropertyIdentifier
         && !is_object_method
         && context.get_node_text(name) == "constructor"
@@ -242,23 +248,36 @@ pub fn get_first_non_comment_child(node: Node) -> Node {
 }
 
 pub trait NodeExtJs<'a> {
-    fn maybe_next_non_parentheses_ancestor(&self) -> Option<Node<'a>>;
-    fn next_non_parentheses_ancestor(&self) -> Node<'a>;
+    fn maybe_next_non_parentheses_ancestor(
+        &self,
+        node_parent_provider: &impl NodeParentProvider<'a>,
+    ) -> Option<Node<'a>>;
+    fn next_non_parentheses_ancestor(
+        &self,
+        node_parent_provider: &impl NodeParentProvider<'a>,
+    ) -> Node<'a>;
     fn skip_parentheses(&self) -> Node<'a>;
     fn is_first_call_expression_argument(&self, call_expression: Node) -> bool;
 }
 
 impl<'a> NodeExtJs<'a> for Node<'a> {
-    fn maybe_next_non_parentheses_ancestor(&self) -> Option<Node<'a>> {
-        let mut node = self.parent()?;
+    fn maybe_next_non_parentheses_ancestor(
+        &self,
+        node_parent_provider: &impl NodeParentProvider<'a>,
+    ) -> Option<Node<'a>> {
+        let mut node = self.maybe_parent(node_parent_provider)?;
         while node.kind() == ParenthesizedExpression {
-            node = node.parent()?;
+            node = node.maybe_parent(node_parent_provider)?;
         }
         Some(node)
     }
 
-    fn next_non_parentheses_ancestor(&self) -> Node<'a> {
-        self.maybe_next_non_parentheses_ancestor().unwrap()
+    fn next_non_parentheses_ancestor(
+        &self,
+        node_parent_provider: &impl NodeParentProvider<'a>,
+    ) -> Node<'a> {
+        self.maybe_next_non_parentheses_ancestor(node_parent_provider)
+            .unwrap()
     }
 
     fn skip_parentheses(&self) -> Node<'a> {
@@ -378,8 +397,11 @@ pub fn is_chain_expression(node: Node) -> bool {
     }
 }
 
-pub fn is_outermost_chain_expression(node: Node) -> bool {
-    is_chain_expression(node) && !is_chain_expression(node.parent().unwrap())
+pub fn is_outermost_chain_expression<'a>(
+    node: Node<'a>,
+    node_parent_provider: &impl NodeParentProvider<'a>,
+) -> bool {
+    is_chain_expression(node) && !is_chain_expression(node.parent_(node_parent_provider))
 }
 
 pub fn is_generator_method_definition(node: Node, context: &QueryMatchContext) -> bool {

--- a/plugin/src/code_path_analysis/code_path_analyzer.rs
+++ b/plugin/src/code_path_analysis/code_path_analyzer.rs
@@ -897,14 +897,16 @@ impl<'a> CodePathAnalyzer<'a> {
             .iter()
             .find(|&&code_path| {
                 let code_path = &self.code_path_arena[code_path];
-                node.is_same_or_descendant_of(code_path.root_node(&self.code_path_segment_arena), self)
-                    && !code_path.child_code_paths.iter().any(|&child_code_path| {
-                        node.is_same_or_descendant_of(
-                            self.code_path_arena[child_code_path]
-                                .root_node(&self.code_path_segment_arena),
-                            self
-                        )
-                    })
+                node.is_same_or_descendant_of(
+                    code_path.root_node(&self.code_path_segment_arena),
+                    self,
+                ) && !code_path.child_code_paths.iter().any(|&child_code_path| {
+                    node.is_same_or_descendant_of(
+                        self.code_path_arena[child_code_path]
+                            .root_node(&self.code_path_segment_arena),
+                        self,
+                    )
+                })
             })
             .copied()
             .unwrap()

--- a/plugin/src/code_path_analysis/code_path_analyzer.rs
+++ b/plugin/src/code_path_analysis/code_path_analyzer.rs
@@ -41,7 +41,10 @@ use crate::{
     EnterOrExit,
 };
 
-fn is_property_definition_value<'a>(node: Node<'a>, node_parent_provider: &impl NodeParentProvider<'a>) -> bool {
+fn is_property_definition_value<'a>(
+    node: Node<'a>,
+    node_parent_provider: &impl NodeParentProvider<'a>,
+) -> bool {
     let parent = node.maybe_parent(node_parent_provider);
 
     parent.matches(|parent| {
@@ -64,7 +67,7 @@ fn is_logical_assignment_operator(operator: &str) -> bool {
 fn get_label<'a>(
     node: Node<'a>,
     source_text_provider: &impl SourceTextProvider<'a>,
-    node_parent_provider: &impl NodeParentProvider<'a>
+    node_parent_provider: &impl NodeParentProvider<'a>,
 ) -> Option<Cow<'a, str>> {
     node.parent_(node_parent_provider)
         .when_kind(LabeledStatement)
@@ -111,7 +114,10 @@ fn get_boolean_value_if_simple_constant<'a>(
     })
 }
 
-fn is_identifier_reference<'a>(node: Node<'a>, node_parent_provider: &impl NodeParentProvider<'a>) -> bool {
+fn is_identifier_reference<'a>(
+    node: Node<'a>,
+    node_parent_provider: &impl NodeParentProvider<'a>,
+) -> bool {
     let parent = node.parent_(node_parent_provider);
 
     match parent.kind() {
@@ -583,7 +589,8 @@ impl<'a> CodePathAnalyzer<'a> {
                     .push_loop_context(
                         &mut self.fork_context_arena,
                         node.kind(),
-                        get_label(node, &self.file_contents, &self.node_parent_provider).map(Cow::into_owned),
+                        get_label(node, &self.file_contents, &self.node_parent_provider)
+                            .map(Cow::into_owned),
                     );
             }
             LabeledStatement => {

--- a/plugin/src/rules/accessor_pairs.rs
+++ b/plugin/src/rules/accessor_pairs.rs
@@ -119,7 +119,7 @@ fn is_property_descriptor(node: Node, context: &QueryMatchContext) -> bool {
             || is_argument_of_method_call(grandparent, 1, "Object", "defineProperties", context))
 }
 
-fn report(node: Node, message_kind: &str, context: &QueryMatchContext) {
+fn report<'a>(node: Node<'a>, message_kind: &str, context: &QueryMatchContext<'a, '_>) {
     match node.kind() {
         MethodDefinition => match node.parent().unwrap().kind() {
             Object => {
@@ -152,7 +152,7 @@ fn report(node: Node, message_kind: &str, context: &QueryMatchContext) {
     }
 }
 
-fn report_list(nodes: &[Node], message_kind: &str, context: &QueryMatchContext) {
+fn report_list<'a>(nodes: &[Node<'a>], message_kind: &str, context: &QueryMatchContext<'a, '_>) {
     for &node in nodes {
         report(node, message_kind, context);
     }

--- a/plugin/src/rules/array_callback_return.rs
+++ b/plugin/src/rules/array_callback_return.rs
@@ -57,9 +57,9 @@ fn get_array_method_name<'a>(
             TernaryExpression | ParenthesizedExpression => current_node = parent,
             ReturnStatement => {
                 let func = ast_utils::get_upper_function(parent)
-                    .filter(|&func| ast_utils::is_callee(func))?;
+                    .filter(|&func| ast_utils::is_callee(func, context))?;
 
-                current_node = func.maybe_next_non_parentheses_ancestor()?;
+                current_node = func.maybe_next_non_parentheses_ancestor(context)?;
             }
             Arguments => {
                 let call_expression = parent.parent().unwrap();

--- a/plugin/src/rules/complexity.rs
+++ b/plugin/src/rules/complexity.rs
@@ -45,9 +45,9 @@ impl Default for Options {
     }
 }
 
-fn report(
-    node: Node,
-    context: &QueryMatchContext,
+fn report<'a>(
+    node: Node<'a>,
+    context: &QueryMatchContext<'a, '_>,
     origin: CodePathOrigin,
     complexity: usize,
     threshold: usize,

--- a/plugin/src/rules/consistent_return.rs
+++ b/plugin/src/rules/consistent_return.rs
@@ -28,7 +28,7 @@ struct FuncInfo {
     data: ViolationData,
 }
 
-fn is_class_constructor(node: Node, context: &QueryMatchContext) -> bool {
+fn is_class_constructor<'a>(node: Node<'a>, context: &QueryMatchContext<'a, '_>) -> bool {
     node.kind() == MethodDefinition
         && get_method_definition_kind(node, context) == MethodDefinitionKind::Constructor
 }

--- a/plugin/src/rules/constructor_super.rs
+++ b/plugin/src/rules/constructor_super.rs
@@ -23,7 +23,7 @@ use crate::{
     CodePathAnalyzer, CodePathSegment, EnterOrExit,
 };
 
-fn is_constructor_function(node: Node, context: &QueryMatchContext) -> bool {
+fn is_constructor_function<'a>(node: Node<'a>, context: &QueryMatchContext<'a, '_>) -> bool {
     node.kind() == MethodDefinition
         && get_method_definition_kind(node, context) == MethodDefinitionKind::Constructor
 }

--- a/plugin/src/rules/max_statements.rs
+++ b/plugin/src/rules/max_statements.rs
@@ -115,11 +115,11 @@ struct TopLevelFunction<'a> {
     count: usize,
 }
 
-fn report_if_too_many_statements(
-    node: Node,
+fn report_if_too_many_statements<'a>(
+    node: Node<'a>,
     count: usize,
     max: usize,
-    context: &QueryMatchContext,
+    context: &QueryMatchContext<'a, '_>,
 ) {
     if count <= max {
         return;

--- a/plugin/src/rules/no_extra_bind.rs
+++ b/plugin/src/rules/no_extra_bind.rs
@@ -31,8 +31,8 @@ fn is_side_effect_free(node: Node) -> bool {
 }
 
 fn report<'a>(node: Node<'a>, context: &QueryMatchContext<'a, '_>) {
-    let member_node = node.next_non_parentheses_ancestor();
-    let call_node = member_node.next_non_parentheses_ancestor();
+    let member_node = node.next_non_parentheses_ancestor(context);
+    let call_node = member_node.next_non_parentheses_ancestor(context);
 
     context.report(violation! {
         node => call_node,
@@ -75,15 +75,15 @@ fn report<'a>(node: Node<'a>, context: &QueryMatchContext<'a, '_>) {
     });
 }
 
-fn is_callee_of_bind_method(node: Node, context: &QueryMatchContext) -> bool {
-    let parent = node.next_non_parentheses_ancestor();
+fn is_callee_of_bind_method<'a>(node: Node<'a>, context: &QueryMatchContext<'a, '_>) -> bool {
+    let parent = node.next_non_parentheses_ancestor(context);
     if !ast_utils::is_specific_member_access(parent, Option::<&str>::None, Some("bind"), context) {
         return false;
     }
 
     let bind_node = parent;
 
-    bind_node.next_non_parentheses_ancestor().thrush(|parent| {
+    bind_node.next_non_parentheses_ancestor(context).thrush(|parent| {
         parent.kind() == CallExpression
             && parent.field("function").skip_parentheses() == bind_node
             && call_expression_has_single_matching_argument(parent, |arg| {

--- a/plugin/src/rules/no_extra_bind.rs
+++ b/plugin/src/rules/no_extra_bind.rs
@@ -83,13 +83,15 @@ fn is_callee_of_bind_method<'a>(node: Node<'a>, context: &QueryMatchContext<'a, 
 
     let bind_node = parent;
 
-    bind_node.next_non_parentheses_ancestor(context).thrush(|parent| {
-        parent.kind() == CallExpression
-            && parent.field("function").skip_parentheses() == bind_node
-            && call_expression_has_single_matching_argument(parent, |arg| {
-                arg.kind() != SpreadElement
-            })
-    })
+    bind_node
+        .next_non_parentheses_ancestor(context)
+        .thrush(|parent| {
+            parent.kind() == CallExpression
+                && parent.field("function").skip_parentheses() == bind_node
+                && call_expression_has_single_matching_argument(parent, |arg| {
+                    arg.kind() != SpreadElement
+                })
+        })
 }
 
 #[derive(Debug)]

--- a/plugin/src/rules/no_extra_label.rs
+++ b/plugin/src/rules/no_extra_label.rs
@@ -80,7 +80,7 @@ pub fn no_extra_label_rule() -> Arc<dyn Rule> {
               (for_in_statement) @c
               (switch_statement) @c
             "# => |node, context| {
-                let parent = node.next_non_parentheses_ancestor();
+                let parent = node.next_non_parentheses_ancestor(context);
                 self.scope_infos.push(ScopeInfo {
                     label: if parent.kind() == LabeledStatement {
                         Some(parent.field("label"))

--- a/plugin/src/rules/no_lonely_if.rs
+++ b/plugin/src/rules/no_lonely_if.rs
@@ -32,7 +32,7 @@ pub fn no_lonely_if_rule() -> Arc<dyn Rule> {
                 )
               )
             "# => |node, context| {
-                if !node.is_only_non_comment_named_sibling(context) {
+                if !node.is_only_non_comment_named_sibling(context, context) {
                     return;
                 }
                 context.report(violation! {

--- a/plugin/src/rules/no_new_symbol.rs
+++ b/plugin/src/rules/no_new_symbol.rs
@@ -23,7 +23,7 @@ pub fn no_new_symbol_rule() -> Arc<dyn Rule> {
                     variable.references().for_each(|ref_| {
                         let id_node = ref_.identifier();
 
-                        if id_node.parent().matches(|parent| {
+                        if id_node.maybe_parent(context).matches(|parent| {
                             parent.kind() == NewExpression && parent.field("constructor") == id_node
                         }) {
                             context.report(violation! {

--- a/plugin/src/rules/no_sequences.rs
+++ b/plugin/src/rules/no_sequences.rs
@@ -75,7 +75,7 @@ pub fn no_sequences_rule() -> Arc<dyn Rule> {
               (sequence_expression) @c
             "# => |node, context| {
                 let parent = node
-                    .next_ancestor_not_of_kinds(&[ExpressionStatement, ParenthesizedExpression]);
+                    .next_ancestor_not_of_kinds(&[ExpressionStatement, ParenthesizedExpression], context);
                 if parent.kind() == ForStatement
                     && (node
                         == parent

--- a/plugin/src/rules/no_this_before_super.rs
+++ b/plugin/src/rules/no_this_before_super.rs
@@ -34,7 +34,7 @@ fn _look_for_this_before_super<'a>(
                 This => {
                     nodes_to_report.insert(*node);
                 }
-                Super if !ast_utils::is_callee(*node) => {
+                Super if !ast_utils::is_callee(*node, code_path_analyzer) => {
                     nodes_to_report.insert(*node);
                 }
                 _ => (),

--- a/plugin/src/rules/no_unreachable.rs
+++ b/plugin/src/rules/no_unreachable.rs
@@ -199,7 +199,7 @@ pub fn no_unreachable_rule() -> Arc<dyn Rule> {
 
                 let has_super_call = self.constructor_infos.pop().unwrap();
 
-                let class_definition = node.parent().unwrap().parent().unwrap();
+                let class_definition = node.parent_(context).parent_(context);
 
                 if class_definition.has_child_of_kind(ClassHeritage) &&
                     !has_super_call {

--- a/plugin/src/rules/no_unreachable.rs
+++ b/plugin/src/rules/no_unreachable.rs
@@ -170,7 +170,7 @@ pub fn no_unreachable_rule() -> Arc<dyn Rule> {
                     .filter(|(node_id, _)| !reachable_nodes.contains(node_id))
                     .map(|(_, node)| node)
                     .collect::<Vec<_>>()
-                    .and_sort_by(compare_nodes)
+                    .and_sort_by(|a, b| compare_nodes(a, b, context))
                     .into_iter()
                     .fold(self.ranges.clone(), |mut ranges, node| {
                         ranges.add(node, context);

--- a/plugin/src/rules/no_unsafe_optional_chaining.rs
+++ b/plugin/src/rules/no_unsafe_optional_chaining.rs
@@ -17,10 +17,10 @@ struct Options {
     disallow_arithmetic_operators: bool,
 }
 
-fn check_undefined_short_circuit(
-    node: Node,
+fn check_undefined_short_circuit<'a>(
+    node: Node<'a>,
     report_func: &impl Fn(Node),
-    context: &QueryMatchContext,
+    context: &QueryMatchContext<'a, '_>,
 ) {
     match node.kind() {
         BinaryExpression => match node.field("operator").kind() {
@@ -50,7 +50,7 @@ fn check_undefined_short_circuit(
             );
         }
         CallExpression | MemberExpression | SubscriptExpression => {
-            if is_outermost_chain_expression(node) {
+            if is_outermost_chain_expression(node, context) {
                 report_func(node);
             }
         }

--- a/plugin/src/rules/no_unused_labels.rs
+++ b/plugin/src/rules/no_unused_labels.rs
@@ -42,7 +42,7 @@ fn is_fixable<'a>(node: Node<'a>, context: &QueryMatchContext<'a, '_>) -> bool {
         return false;
     }
 
-    let ancestor = node.next_ancestor_not_of_kind(LabeledStatement);
+    let ancestor = node.next_ancestor_not_of_kind(LabeledStatement, context);
 
     #[allow(clippy::collapsible_if)]
     if ancestor.kind() == Program

--- a/plugin/src/rules/no_unused_vars.rs
+++ b/plugin/src/rules/no_unused_vars.rs
@@ -503,7 +503,7 @@ pub fn no_unused_vars_rule() -> Arc<dyn Rule> {
                 &self,
                 scope: Scope<'a, 'b>,
                 unused_vars: &mut Vec<Variable<'a, 'b>>,
-                context: &QueryMatchContext,
+                context: &QueryMatchContext<'a, '_>,
                 scope_manager: &ScopeManager<'a>,
             ) {
                 if scope.type_() != ScopeType::Global || self.vars == Vars::All {

--- a/plugin/src/rules/no_useless_return.rs
+++ b/plugin/src/rules/no_useless_return.rs
@@ -156,7 +156,7 @@ pub fn no_useless_return_rule() -> Arc<dyn Rule> {
                     }
                 }
 
-                nodes_to_report.sort_by(compare_nodes);
+                nodes_to_report.sort_by(|a, b| compare_nodes(a, b, context));
                 nodes_to_report.dedup();
 
                 for node in nodes_to_report {

--- a/plugin/src/rules/radix.rs
+++ b/plugin/src/rules/radix.rs
@@ -126,8 +126,8 @@ pub fn radix_rule() -> Arc<dyn Rule> {
                     variable.references().for_each(|reference| {
                         let id_node = reference.identifier();
 
-                        if ast_utils::is_callee(id_node) {
-                            self.check_arguments(id_node.next_non_parentheses_ancestor(), context);
+                        if ast_utils::is_callee(id_node, context) {
+                            self.check_arguments(id_node.next_non_parentheses_ancestor(context), context);
                         }
                     });
                 }
@@ -140,8 +140,8 @@ pub fn radix_rule() -> Arc<dyn Rule> {
                         let parent_node = reference.identifier().parent().unwrap();
                         let maybe_callee = parent_node;
 
-                        if is_parse_int_method(parent_node, context) && ast_utils::is_callee(maybe_callee) {
-                            self.check_arguments(maybe_callee.next_non_parentheses_ancestor(), context);
+                        if is_parse_int_method(parent_node, context) && ast_utils::is_callee(maybe_callee, context) {
+                            self.check_arguments(maybe_callee.next_non_parentheses_ancestor(context), context);
                         }
                     });
                 }

--- a/plugin/src/rules/symbol_description.rs
+++ b/plugin/src/rules/symbol_description.rs
@@ -31,7 +31,7 @@ pub fn symbol_description_rule() -> Arc<dyn Rule> {
                     variable.references().for_each(|reference| {
                         let id_node = reference.identifier();
 
-                        if ast_utils::is_callee(id_node) {
+                        if ast_utils::is_callee(id_node, context) {
                             check_argument(id_node.parent().unwrap(), context);
                         }
                     });

--- a/plugin/src/rules/yoda.rs
+++ b/plugin/src/rules/yoda.rs
@@ -334,7 +334,7 @@ pub fn yoda_rule() -> Arc<dyn Rule> {
                         looks_like_literal(expected_literal)
                     ) &&
                     !(self.only_equality && !is_equality_operator(node.field("operator").kind())) &&
-                    !(self.except_range && is_range_test(node.next_non_parentheses_ancestor(), context)) {
+                    !(self.except_range && is_range_test(node.next_non_parentheses_ancestor(context), context)) {
                     context.report(violation! {
                         node => node,
                         message_id => "expected",

--- a/plugin/src/tests/scope_analysis/get_declared_variables.rs
+++ b/plugin/src/tests/scope_analysis/get_declared_variables.rs
@@ -2,7 +2,10 @@
 
 use itertools::Itertools;
 use speculoos::prelude::*;
-use tree_sitter_lint::tree_sitter::{Node, Tree};
+use tree_sitter_lint::{
+    tree_sitter::{Node, Tree},
+    walk_tree, TreeEnterLeaveVisitor,
+};
 
 use crate::{
     ast_helpers::is_default_import,
@@ -14,7 +17,6 @@ use crate::{
     },
     scope::{analyze, ScopeManager, ScopeManagerOptionsBuilder, SourceType},
     tests::helpers::{parse, tracing_subscribe},
-    visit::{walk_tree, TreeEnterLeaveVisitor},
 };
 
 struct VerifyEnterLeaveVisitor<'a, 'b> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,7 +65,7 @@ fn dump_dot_file(source_text: &str) {
         source_text.as_bytes(),
         None,
         "tmp.js",
-        ConfigBuilder::default()
+        &ConfigBuilder::default()
             .rule(rule.meta().name.clone())
             .all_standalone_rules([rule.clone()])
             .rule_configurations([RuleConfiguration {
@@ -77,5 +77,6 @@ fn dump_dot_file(source_text: &str) {
             .unwrap(),
         tree_sitter_lint::tree_sitter_grep::SupportedLanguageLanguage::Javascript,
         &*get_instance_provider_factory(),
+        None,
     );
 }


### PR DESCRIPTION
In this PR:
- use the updated tree-sitter-lint API's for more optimized node parent finding in a couple places (eg tried to update all places in code path analysis since this was driven by doing profiling and seeing that (a) code path analysis was taking a long time (b) `Node::parent()` seemed to be the expensive thing in code path analysis)

Not in this PR:
- going through and changing all uses of `Node::parent()` to use the more optimized node-parent finding API's instead

To test:
Things should still work. There was some stuff with the tracing-logging itself being costly but I definitely saw a ~50% reduction in the time spent doing code path analysis after these switches and for a large file was seeing code path analysis only cost ~4ms in a CLI run 